### PR TITLE
Update check-mem

### DIFF
--- a/files/default/plugins/system/check-mem
+++ b/files/default/plugins/system/check-mem
@@ -72,7 +72,7 @@ if [ -n "$int_warn" -a -n "$int_crit" ]; then
       echo "MEM WARNING - $OUTPUTP"
       exit "$err"
     else
-      echo "MEM WARNING - $OUTOUT"
+      echo "MEM WARNING - $OUTPUT"
       exit "$err"
     fi
 


### PR DESCRIPTION
OUTPUT was misspelled as OUTOUT in warning.
